### PR TITLE
해더에 해시태그 메뉴 추가하기

### DIFF
--- a/src/main/resources/templates/header.html
+++ b/src/main/resources/templates/header.html
@@ -14,12 +14,8 @@
             </ul>
 
             <div class="text-end">
-                <span id="username" class="text-white me-2">username</span>
-                <a role="button" id="login" class="btn btn-outline-light me-2">Login</a>
-                <a role="button" id="kakao-login" class="me-2">
-<!--                    <img alt="Kakao Login" src="/images/kakao_login_medium.png">-->
-                </a>
-                <a role="button" id="logout" class="btn btn-outline-light me-2">Logout</a>
+                <button type="button" class="btn btn-outline-light me-2">Login</button>
+                <button type="button" class="btn btn-warning">Sign-up</button>
             </div>
         </div>
     </div>

--- a/src/main/resources/templates/header.th.xml
+++ b/src/main/resources/templates/header.th.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0"?>
+<thlogic>
+    <attr sel="#home" th:href="@{/}" />
+    <attr sel="#hashtag" th:href="@{/articles/search-hashtag}" />
+</thlogic>


### PR DESCRIPTION
링크는 타임리프 태그로 처리하도록 변경
이러면 스프링 부트로 띄우지 않은 정적 목업 페이지는 링크 동작을 보여주지 않아서 리소스 접근에 안전함