### PR TITLE
엔티티 equals() 버그 수정

### DIFF
--- a/src/main/java/com/example/boardpractice/domain/Article.java
+++ b/src/main/java/com/example/boardpractice/domain/Article.java
@@ -58,8 +58,8 @@ public class Article extends AuditingFields{
     @Override
     public boolean equals(Object o) {
         if (this == o) return true;
-        if (!(o instanceof Article article)) return false;
-        return id != null && id.equals(article.id);
+        if (!(o instanceof Article that)) return false;
+        return id != null && id.equals(that.getId());
     }
 
     @Override

--- a/src/main/java/com/example/boardpractice/domain/ArticleComment.java
+++ b/src/main/java/com/example/boardpractice/domain/ArticleComment.java
@@ -44,7 +44,7 @@ public class ArticleComment extends AuditingFields{
     public boolean equals(Object o) {
         if (this == o) return true;
         if (!(o instanceof ArticleComment that)) return false;
-        return id != null && id.equals(that.id);
+        return id != null && id.equals(that.getId());
     }
 
     @Override

--- a/src/main/java/com/example/boardpractice/domain/UserAccount.java
+++ b/src/main/java/com/example/boardpractice/domain/UserAccount.java
@@ -44,8 +44,8 @@ public class UserAccount extends AuditingFields {
     @Override
     public boolean equals(Object o) {
         if (this == o) return true;
-        if (!(o instanceof UserAccount userAccount)) return false;
-        return userId != null && userId.equals(userAccount.userId);
+        if (!(o instanceof UserAccount that)) return false;
+        return userId != null && userId.equals(that.getUserId());
     }
 
     @Override


### PR DESCRIPTION
테스트해보니 'that.id'와 같은 표현은
의도하지 않은 동작을 만듬
제대로 getter를 써서 값을 불러오게 수정
이름도 'that'으로 통일